### PR TITLE
geom_alt props

### DIFF
--- a/data/101/831/917/101831917.geojson
+++ b/data/101/831/917/101831917.geojson
@@ -829,6 +829,9 @@
         85633285
     ],
     "wof:country":"MC",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c6267206e579bf3def8aae754f9683e",
     "wof:hierarchy":[
         {
@@ -839,7 +842,7 @@
         }
     ],
     "wof:id":101831917,
-    "wof:lastmodified":1566602965,
+    "wof:lastmodified":1582316360,
     "wof:megacity":0,
     "wof:name":"Monaco",
     "wof:parent_id":85686311,

--- a/data/856/332/85/85633285.geojson
+++ b/data/856/332/85/85633285.geojson
@@ -1048,7 +1048,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1124,7 +1123,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1582316360,
+    "wof:lastmodified":1583203178,
     "wof:name":"Monaco",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/85/85633285.geojson
+++ b/data/856/332/85/85633285.geojson
@@ -1048,6 +1048,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes",
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1104,6 +1105,11 @@
     ],
     "wof:country":"MC",
     "wof:country_alpha3":"MCO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"52c3b18f9d1eee3741f379f1f92d8787",
     "wof:hierarchy":[
         {
@@ -1118,7 +1124,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566602964,
+    "wof:lastmodified":1582316360,
     "wof:name":"Monaco",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/857/941/35/85794135.geojson
+++ b/data/857/941/35/85794135.geojson
@@ -182,6 +182,9 @@
         "wk:page":"La Condamine"
     },
     "wof:country":"MC",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"232d31636e126417c05aa363cd530255",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566602964,
+    "wof:lastmodified":1582316360,
     "wof:name":"La Condamine",
     "wof:parent_id":101831917,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/37/85794137.geojson
+++ b/data/857/941/37/85794137.geojson
@@ -114,6 +114,9 @@
         "wd:id":"Q55089"
     },
     "wof:country":"MC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"382190b3fe8871e8e11ca30df069ec99",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566602964,
+    "wof:lastmodified":1582316360,
     "wof:name":"St.-Roman",
     "wof:parent_id":101831915,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.