### PR TITLE
Flag coterminous places

### DIFF
--- a/data/101/831/917/101831917.geojson
+++ b/data/101/831/917/101831917.geojson
@@ -828,7 +828,8 @@
         "qs_pg:id":1078166
     },
     "wof:coterminous":[
-        85633285
+        85633285,
+        85686311
     ],
     "wof:country":"MC",
     "wof:geom_alt":[
@@ -844,7 +845,7 @@
         }
     ],
     "wof:id":101831917,
-    "wof:lastmodified":1607390899,
+    "wof:lastmodified":1608004479,
     "wof:megacity":0,
     "wof:name":"Monaco",
     "wof:parent_id":85686311,


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1906.

This PR attempts flag any locality, localadmin, county, macrocounty, or region record as coterminous with any parent records that are similar in size and have similar names.