### PR TITLE
mc concordances, placetype local, and more

### DIFF
--- a/data/856/332/85/85633285.geojson
+++ b/data/856/332/85/85633285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000391,
-    "geom:area_square_m":3497609.096912,
+    "geom:area_square_m":3497599.974689,
     "geom:bbox":"7.409048,43.724414,7.447348,43.751952",
     "geom:latitude":43.737925,
     "geom:longitude":7.427694,
@@ -13,6 +13,9 @@
     "iso:country":"MC",
     "itu:country_code":[
         "377"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "MC"
@@ -1209,7 +1212,8 @@
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"377",
     "statoids:ds":"MC",
     "statoids:fifa":"MON",
@@ -1269,7 +1273,7 @@
         "naturalearth-display-terrestrial-zoom6",
         "naturalearth"
     ],
-    "wof:geomhash":"370921f89f75d49a015c739e8af7f5fd",
+    "wof:geomhash":"3155f4d622ae5637125103e1f88264c0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1283,12 +1287,12 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939124,
+    "wof:lastmodified":1694492224,
     "wof:name":"Monaco",
     "wof:parent_id":102191581,
     "wof:placetype":"country",
-    "wof:population":37831,
-    "wof:population_rank":7,
+    "wof:population":38964,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-mc",
     "wof:shortcode":"MC",
     "wof:superseded_by":[],

--- a/data/856/332/85/85633285.geojson
+++ b/data/856/332/85/85633285.geojson
@@ -1213,7 +1213,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"377",
     "statoids:ds":"MC",
     "statoids:fifa":"MON",
@@ -1287,7 +1287,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694492224,
+    "wof:lastmodified":1694639679,
     "wof:name":"Monaco",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/85/85633285.geojson
+++ b/data/856/332/85/85633285.geojson
@@ -1251,6 +1251,7 @@
         "hasc:id":"MC",
         "icao:code":"3A",
         "ioc:id":"MON",
+        "iso:code":"MC",
         "itu:id":"MCO",
         "m49:code":"492",
         "marc:id":"mc",
@@ -1263,6 +1264,7 @@
         "wd:id":"Q235",
         "wk:page":"Monaco"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85686311
     ],
@@ -1287,7 +1289,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639679,
+    "wof:lastmodified":1695881337,
     "wof:name":"Monaco",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/863/11/85686311.geojson
+++ b/data/856/863/11/85686311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000242,
-    "geom:area_square_m":2157740.042417,
+    "geom:area_square_m":2157732.683703,
     "geom:bbox":"7.409525,43.725727,7.439247,43.751632",
     "geom:latitude":43.737453,
     "geom:longitude":7.424219,
@@ -280,15 +280,21 @@
     "wof:concordances":{
         "fips:code":"MN",
         "hasc:id":"MC.MC",
+        "iso:code":"MC-MC",
         "iso:id":"MC-MC",
+        "qs:local_id":"N_A",
         "wd:id":"Q55115"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101831917,
         85633285
     ],
     "wof:country":"MC",
-    "wof:geomhash":"fc1a2f1167c54295d912817becf8dae9",
+    "wof:geomhash":"e7c6df5b6226b67335dc5cf6ed592704",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -303,7 +309,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939124,
+    "wof:lastmodified":1695884786,
     "wof:name":"Monaco",
     "wof:parent_id":85633285,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.